### PR TITLE
minted: fix linenos in PDF & fix clean rules

### DIFF
--- a/00_mu-tutoriel/Makefile
+++ b/00_mu-tutoriel/Makefile
@@ -15,6 +15,6 @@ all: ${SUBJECT}.pdf ${SUBJECT}.tex
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/01_decouverte/Makefile
+++ b/01_decouverte/Makefile
@@ -15,6 +15,6 @@ all: ${SUBJECT}.pdf ${SUBJECT}.tex
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/01_decouverte_micropython/Makefile
+++ b/01_decouverte_micropython/Makefile
@@ -19,6 +19,6 @@ figures:
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/02_listes_et_string/Makefile
+++ b/02_listes_et_string/Makefile
@@ -15,6 +15,6 @@ all: ${SUBJECT}.pdf ${SUBJECT}.tex
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/03_reseau/Makefile
+++ b/03_reseau/Makefile
@@ -15,6 +15,6 @@ all: ${SUBJECT}.pdf ${SUBJECT}.tex
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/04_objet/Makefile
+++ b/04_objet/Makefile
@@ -15,6 +15,6 @@ all: ${SUBJECT}.pdf ${SUBJECT}.tex
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/04_web/Makefile
+++ b/04_web/Makefile
@@ -15,6 +15,6 @@ all: $(SUBJECTS:=.pdf) $(SUBJECTS:=.tex)
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECTS:=.tex}
+	latexmk -C ${SUBJECTS:=.tex} -f
 	${RM} ${SUBJECTS:=.tex}
 	${RM} -rf ${SUBJECTS:%=_minted-%}

--- a/04_web_boni/Makefile
+++ b/04_web_boni/Makefile
@@ -15,6 +15,6 @@ all: $(SUBJECTS:=.pdf) $(SUBJECTS:=.tex)
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECTS:=.tex}
+	latexmk -C ${SUBJECTS:=.tex} -f
 	${RM} ${SUBJECTS:=.tex}
 	${RM} -rf ${SUBJECTS:%=_minted-%}

--- a/05_projet_jeu/Makefile
+++ b/05_projet_jeu/Makefile
@@ -5,4 +5,5 @@ all: 05_projet_jeu.pdf
 	mv old_template.pdf 05_projet_jeu.pdf
 
 clean:
-	latexmk -C
+	latexmk -C -f
+	rm -rf _minted-old_template

--- a/05_projet_jeu/old_template.tex
+++ b/05_projet_jeu/old_template.tex
@@ -4,6 +4,7 @@
 \usepackage[french]{babel}
 \usepackage[most]{tcolorbox}
 \usepackage[utf8]{inputenc}
+\usepackage{accsupp}
 \usepackage{colortbl}
 \usepackage{fancyhdr}
 \usepackage{framed}
@@ -35,6 +36,13 @@
 \cfoot{\thepage}
 \fancyfoot[L]{\includegraphics[width=2cm]{../logo_gcc_court.pdf}}
 \fancyfoot[R]{\includegraphics[width=1.2cm]{../prologin_cube_bw.pdf}}
+
+% No copy linenos : https://tex.stackexchange.com/questions/83204/how-can-i-make-source-code-included-with-minted-copyable
+
+\newcommand\emptyaccsupp[1]{\BeginAccSupp{ActualText={}}#1\EndAccSupp{}}
+
+\let\theHFancyVerbLine\theFancyVerbLine % don't apply our patch to hyperref's version
+\def\theFancyVerbLine{\rmfamily\tiny\emptyaccsupp{\arabic{FancyVerbLine}}}
 
 \definecolor{grey}{RGB}{240, 240, 240}
 \setminted[text]{bgcolor=grey}

--- a/05_projet_microbit/Makefile
+++ b/05_projet_microbit/Makefile
@@ -15,6 +15,6 @@ all: ${SUBJECT}.pdf ${SUBJECT}.tex
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,21 @@ TARGETS = \
 	bonus_python_avance.pdf \
 	bonus_unix.pdf
 
+DIRS = \
+	00_mu-tutoriel \
+	01_decouverte_micropython \
+	01_decouverte \
+	01_decouverte_micropython \
+	02_listes_et_string \
+	03_reseau \
+	04_objet \
+	04_web \
+	04_web_boni \
+	05_projet_jeu \
+	05_projet_microbit \
+	bonus_python_avance \
+	bonus_unix
+
 COLLECT_DIR = build
 
 all: $(addprefix $(COLLECT_DIR)/, $(TARGETS))
@@ -21,3 +36,8 @@ $(COLLECT_DIR)/%.pdf:
 	make -C $*
 	mkdir -p $(COLLECT_DIR)
 	cp $*/$*.pdf $@
+
+clean:
+	for dir in $(DIRS); do \
+	    make clean -C $$dir; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,4 @@ clean:
 	for dir in $(DIRS); do \
 	    make clean -C $$dir; \
 	done
+	rm -rf $(COLLECT_DIR)

--- a/bonus_python_avance/Makefile
+++ b/bonus_python_avance/Makefile
@@ -15,6 +15,6 @@ all: ${SUBJECT}.pdf ${SUBJECT}.tex
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/bonus_unix/Makefile
+++ b/bonus_unix/Makefile
@@ -15,6 +15,6 @@ all: ${SUBJECT}.pdf ${SUBJECT}.tex
 
 .PHONY: clean
 clean:
-	latexmk -C ${SUBJECT}.tex
+	latexmk -C ${SUBJECT}.tex -f
 	${RM} ${SUBJECT}.tex
 	${RM} -rf _minted-${SUBJECT}

--- a/template/gcc.tex
+++ b/template/gcc.tex
@@ -9,6 +9,7 @@
 \usepackage[breaklinks=true]{hyperref}
 \usepackage[french]{babel}
 \usepackage[most]{tcolorbox}
+\usepackage{accsupp}
 \usepackage{amsmath}
 \usepackage{array}
 \usepackage{booktabs}
@@ -73,6 +74,13 @@ urlcolor=blue}
 \cfoot{\thepage}
 \fancyfoot[L]{\includegraphics[width=2cm]{../logo_gcc_court.pdf}}
 \fancyfoot[R]{\includegraphics[width=1.2cm]{../prologin_cube_bw.pdf}}
+
+% No copy linenos : https://tex.stackexchange.com/questions/83204/how-can-i-make-source-code-included-with-minted-copyable
+
+\newcommand\emptyaccsupp[1]{\BeginAccSupp{ActualText={}}#1\EndAccSupp{}}
+
+\let\theHFancyVerbLine\theFancyVerbLine % don't apply our patch to hyperref's version
+\def\theFancyVerbLine{\rmfamily\tiny\emptyaccsupp{\arabic{FancyVerbLine}}}
 
 % Custom color environments
 \definecolor{grey}{RGB}{240, 240, 240}


### PR DESCRIPTION
For the Makefiles : if corrects the clean rules, so that we can `make clean` from the top folder.

For minted, it overrides the  `theFancyVerbLine` macro in order to remove the line numbers in the PDF, thus preventing them from being copy-pasted. They will be replaced by nothing, but will still be shown, thanks to `ActualText={}`.