### PR TITLE
template: fix figures sizes

### DIFF
--- a/template/gcc.tex
+++ b/template/gcc.tex
@@ -97,7 +97,13 @@
 % Remove section numbering
 \makeatletter
 \renewcommand{\@seccntformat}[1]{}
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
 \makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
 
 \title{
     \protect\centering\protect\includegraphics[height=3cm]{../logo_gcc_long.pdf}\\


### PR DESCRIPTION
Pandoc does not properly handle graphics/figures sizes without these few lines.
This workaround comes from https://github.com/jgm/pandoc/issues/4384